### PR TITLE
Fix remarket player with lower value

### DIFF
--- a/src/app/leagues/[leagueId]/[teamId]/players/page.tsx
+++ b/src/app/leagues/[leagueId]/[teamId]/players/page.tsx
@@ -87,7 +87,6 @@ export default function TeamPlayersPage() {
         const playerName = player.nickname || player.name
 
         try {
-          // Ensure player has sale info (should always be true in this loop)
           if (!player.saleInfo) continue
 
           // Step 1: Withdraw player from market
@@ -113,7 +112,7 @@ export default function TeamPlayersPage() {
             token,
             leagueId,
             playerIdToSell,
-            player.saleInfo.salePrice
+            player.marketValue
           )
 
           if (sellResult.error) {


### PR DESCRIPTION
This pull request makes minor adjustments to the logic for selling a player in the `TeamPlayersPage` component. The main change is to use the player's `marketValue` instead of their `saleInfo.salePrice` when initiating a sale.

* Updated the sale logic to use `player.marketValue` rather than `player.saleInfo.salePrice` when selling a player. ([src/app/leagues/[leagueId]/[teamId]/players/page.tsxL116-R115](diffhunk://#diff-96bccfae5b4af1e994157cd71827da90b011c8ac9bd1b1e0acf56ac92eb72a68L116-R115))
* Removed a redundant comment about sale info checks in the player sale loop. ([src/app/leagues/[leagueId]/[teamId]/players/page.tsxL90](diffhunk://#diff-96bccfae5b4af1e994157cd71827da90b011c8ac9bd1b1e0acf56ac92eb72a68L90))