### PR TITLE
fix: remarket players when no players are in the market

### DIFF
--- a/src/app/leagues/[leagueId]/[teamId]/players/page.tsx
+++ b/src/app/leagues/[leagueId]/[teamId]/players/page.tsx
@@ -223,7 +223,7 @@ export default function TeamPlayersPage() {
                   disabled={
                     remarketingAll ||
                     loading ||
-                    players.filter((p) => p.saleInfo).length === 0
+                    players.length === 0
                   }
                   className="flex items-center gap-2"
                 >


### PR DESCRIPTION
This pull request makes a small change to the logic that determines when a button is disabled on the team players page. Now, the button will be disabled if there are no players on the team, rather than only when there are no players with `saleInfo`. ([src/app/leagues/[leagueId]/[teamId]/players/page.tsxL226-R226](diffhunk://#diff-96bccfae5b4af1e994157cd71827da90b011c8ac9bd1b1e0acf56ac92eb72a68L226-R226))