### PR TITLE
Fix login behind the production reverse proxy

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -4,6 +4,7 @@ import {
   getTokenLifetimeSeconds,
   isValidProviderToken,
 } from '@/lib/auth-session'
+import { isSameOriginRequest } from '@/lib/request-origin'
 
 const CLIENT_ID = 'af88bcff-1157-40a0-b579-030728aacf0b'
 const TOKEN_URL =
@@ -19,13 +20,8 @@ function noStoreJson(body: unknown, status = 200): NextResponse {
   })
 }
 
-function isSameOrigin(request: NextRequest): boolean {
-  const origin = request.headers.get('origin')
-  return !origin || origin === request.nextUrl.origin
-}
-
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (!isSameOrigin(request)) {
+  if (!isSameOriginRequest(request, true)) {
     return noStoreJson({ error: 'Request origin is not allowed' }, 403)
   }
 

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { AUTH_COOKIE_NAME, getTokenLifetimeSeconds } from '@/lib/auth-session'
+import { isSameOriginRequest } from '@/lib/request-origin'
 
 function response(authenticated: boolean): NextResponse {
   return NextResponse.json(
@@ -21,8 +22,7 @@ export function GET(request: NextRequest): NextResponse {
 }
 
 export function DELETE(request: NextRequest): NextResponse {
-  const origin = request.headers.get('origin')
-  if (origin && origin !== request.nextUrl.origin) {
+  if (!isSameOriginRequest(request, true)) {
     return NextResponse.json(
       { error: 'Request origin is not allowed' },
       { status: 403, headers: { 'Cache-Control': 'no-store' } }

--- a/src/app/api/fantasy/route.ts
+++ b/src/app/api/fantasy/route.ts
@@ -5,13 +5,10 @@ import {
   preserveUpstreamResponse,
   validateFantasyRequestBody,
 } from '@/lib/fantasy-proxy'
+import { isSameOriginRequest } from '@/lib/request-origin'
 
 const API_BASE_URL = 'https://fantasy-api.llt-services.com/api'
 const MAX_REQUEST_BODY_BYTES = 64 * 1024
-
-function isSameOrigin(request: NextRequest): boolean {
-  return request.headers.get('origin') === request.nextUrl.origin
-}
 
 async function proxyRequest(request: NextRequest): Promise<Response> {
   const method = request.method.toUpperCase()
@@ -25,7 +22,7 @@ async function proxyRequest(request: NextRequest): Promise<Response> {
     )
   }
 
-  if (method !== 'GET' && !isSameOrigin(request)) {
+  if (method !== 'GET' && !isSameOriginRequest(request)) {
     return Response.json(
       { error: 'Request origin is not allowed' },
       { status: 403 }

--- a/src/lib/request-origin.ts
+++ b/src/lib/request-origin.ts
@@ -1,0 +1,41 @@
+type OriginRequest = {
+  headers: Headers
+  nextUrl: URL
+}
+
+function firstForwardedValue(value: string | null): string | null {
+  const first = value?.split(',', 1)[0]?.trim()
+  return first || null
+}
+
+function getPublicOrigin(request: OriginRequest): string | null {
+  const host =
+    firstForwardedValue(request.headers.get('x-forwarded-host')) ||
+    request.headers.get('host')?.trim() ||
+    request.nextUrl.host
+  const protocol =
+    firstForwardedValue(request.headers.get('x-forwarded-proto')) ||
+    request.nextUrl.protocol.replace(/:$/, '')
+
+  if (!host || (protocol !== 'http' && protocol !== 'https')) return null
+
+  try {
+    return new URL(`${protocol}://${host}`).origin
+  } catch {
+    return null
+  }
+}
+
+export function isSameOriginRequest(
+  request: OriginRequest,
+  allowMissingOrigin = false
+): boolean {
+  const origin = request.headers.get('origin')
+  if (!origin) return allowMissingOrigin
+
+  try {
+    return new URL(origin).origin === getPublicOrigin(request)
+  } catch {
+    return false
+  }
+}

--- a/tests/request-origin.test.ts
+++ b/tests/request-origin.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isSameOriginRequest } from '../src/lib/request-origin.ts'
+
+function request(
+  origin: string | null,
+  headers: Record<string, string> = {},
+  internalUrl = 'http://localhost:3000/api/auth/login'
+) {
+  const requestHeaders = new Headers(headers)
+  if (origin) requestHeaders.set('origin', origin)
+
+  return {
+    headers: requestHeaders,
+    nextUrl: new URL(internalUrl),
+  }
+}
+
+test('accepts a direct same-origin request', () => {
+  assert.equal(
+    isSameOriginRequest(
+      request('http://localhost:3000', { host: 'localhost:3000' })
+    ),
+    true
+  )
+})
+
+test('reconstructs the public HTTPS origin behind a reverse proxy', () => {
+  assert.equal(
+    isSameOriginRequest(
+      request('https://laligafantasy.xyz', {
+        host: 'laligafantasy.xyz',
+        'x-forwarded-proto': 'https',
+      })
+    ),
+    true
+  )
+})
+
+test('uses an explicit forwarded host when the proxy rewrites Host', () => {
+  assert.equal(
+    isSameOriginRequest(
+      request('https://laligafantasy.xyz', {
+        host: 'localhost:3000',
+        'x-forwarded-host': 'laligafantasy.xyz',
+        'x-forwarded-proto': 'https',
+      })
+    ),
+    true
+  )
+})
+
+test('rejects a different host or protocol behind a reverse proxy', () => {
+  const headers = {
+    host: 'localhost:3000',
+    'x-forwarded-host': 'laligafantasy.xyz',
+    'x-forwarded-proto': 'https',
+  }
+
+  assert.equal(
+    isSameOriginRequest(request('https://attacker.example', headers)),
+    false
+  )
+  assert.equal(
+    isSameOriginRequest(request('http://laligafantasy.xyz', headers)),
+    false
+  )
+})
+
+test('rejects missing or malformed origins unless explicitly allowed', () => {
+  assert.equal(isSameOriginRequest(request(null)), false)
+  assert.equal(isSameOriginRequest(request(null), true), true)
+  assert.equal(isSameOriginRequest(request('not a URL')), false)
+})


### PR DESCRIPTION
## What changed

- Reconstruct same-origin checks from the public proxy host and protocol.
- Reuse the validation for login, logout, and Fantasy API mutations.
- Keep cross-origin and malformed requests blocked.

## Why

In production, Next.js sees the internal http://localhost:3001 URL behind Apache, so valid requests from https://laligafantasy.xyz were rejected with Request origin is not allowed.

## Validation

- pnpm check (36 tests)
- pnpm build
- Production smoke test: public origin reaches request validation; foreign origin remains 403